### PR TITLE
Ciel: fix various packing problems

### DIFF
--- a/pkgs/tools/package-management/ciel/0001-use-canonicalize-path-to-find-libexec.patch
+++ b/pkgs/tools/package-management/ciel/0001-use-canonicalize-path-to-find-libexec.patch
@@ -1,0 +1,55 @@
+From 17f41538ed1057e855540f5abef7faf6ea4abf5c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?=E7=99=BE=E5=9C=B0=20=E5=B8=8C=E7=95=99=E8=80=B6?=
+ <65301509+KiruyaMomochi@users.noreply.github.com>
+Date: Sun, 12 Mar 2023 01:01:10 +0800
+Subject: [PATCH] cli,completions: use canonicalize path to find libexec
+ location
+
+---
+ completions/ciel.bash | 2 +-
+ completions/ciel.fish | 2 +-
+ src/cli.rs            | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/completions/ciel.bash b/completions/ciel.bash
+index 733cfda..e5efb5f 100644
+--- a/completions/ciel.bash
++++ b/completions/ciel.bash
+@@ -29,7 +29,7 @@ _ciel_list_packages() {
+ }
+ 
+ _ciel_list_plugins() {
+-    local CIEL="$(command -v ciel)"
++    local CIEL="$(readlink -f $(command -v ciel))"
+     [ -z "$CIEL" ] && return
+     local PLUGIN_DIR="$(dirname $CIEL)/../libexec/ciel-plugin"
+     find "$PLUGIN_DIR" -maxdepth 1 -mindepth 1 -type f -name 'ciel-*' -printf '%f\n' | cut -d'-' -f2-
+diff --git a/completions/ciel.fish b/completions/ciel.fish
+index 3c70817..56a9a84 100644
+--- a/completions/ciel.fish
++++ b/completions/ciel.fish
+@@ -30,7 +30,7 @@ function __ciel_list_packages
+ end
+ 
+ function __ciel_list_plugins
+-    set ciel_path (command -v ciel)
++    set ciel_path (readlink -f (command -v ciel))
+     set ciel_plugin_dir (dirname $ciel_path)"/../libexec/ciel-plugin"
+     find "$ciel_plugin_dir" -maxdepth 1 -mindepth 1 -type f -printf '%f\t-Ciel plugin-\n' | cut -d'-' -f2-
+ end
+diff --git a/src/cli.rs b/src/cli.rs
+index b6d7d24..56671b1 100644
+--- a/src/cli.rs
++++ b/src/cli.rs
+@@ -6,7 +6,7 @@ pub const GIT_TREE_URL: &str = "https://github.com/AOSC-Dev/aosc-os-abbs.git";
+ 
+ /// List all the available plugins/helper scripts
+ fn list_helpers() -> Result<Vec<String>> {
+-    let exe_dir = std::env::current_exe()?;
++    let exe_dir = std::env::current_exe().and_then(std::fs::canonicalize)?;
+     let exe_dir = exe_dir.parent().ok_or_else(|| anyhow!("Where am I?"))?;
+     let plugins_dir = exe_dir.join("../libexec/ciel-plugin/").read_dir()?;
+     let plugins = plugins_dir
+-- 
+2.39.2
+

--- a/pkgs/tools/package-management/ciel/default.nix
+++ b/pkgs/tools/package-management/ciel/default.nix
@@ -31,6 +31,9 @@ rustPlatform.buildRustPackage rec {
 
   postInstall = ''
     mv -v "$out/bin/ciel-rs" "$out/bin/ciel"
+    env PREFIX="$out/" ./install-assets.sh
+    # https://github.com/AOSC-Dev/ciel-rs/pull/15
+    mv -v $out/share/fish/completions $out/share/fish/vendor_completions.d
   '';
 
   meta = with lib; {

--- a/pkgs/tools/package-management/ciel/default.nix
+++ b/pkgs/tools/package-management/ciel/default.nix
@@ -19,33 +19,23 @@ rustPlatform.buildRustPackage rec {
   src = fetchFromGitHub {
     owner = "AOSC-Dev";
     repo = "ciel-rs";
-    rev = "02eac316765f27239b7b17176df812da702895cd";
+    rev = "refs/tags/v{version}";
     hash = "sha256-WzrOCiIOdg3fBLKNjCPlr/XGrXC2424hO1nrwWXjx2A=";
   };
 
-  nativeBuildInputs = [ pkg-config zlib ];
+  cargoHash = "sha256-qGWRw71jrS7sl9+SYVff6aM6tXAFu3NGWWZkJ/vhwaY=";
 
-  doCheck = false;
+  nativeBuildInputs = [ pkg-config ];
 
-  buildInputs = [ systemd dbus openssl libssh2 libgit2 xz ];
-
-  cargoLock = {
-    lockFile = fetchurl {
-      url = "https://raw.githubusercontent.com/AOSC-Dev/ciel-rs/02eac316765f27239b7b17176df812da702895cd/Cargo.lock";
-      sha256 = "sha256-hFjKf3psCj9ntQaKpVjeIhnWh5EzKphsTr82LXZ9XsA=";
-    };
-    outputHashes = {
-      "libmount-0.1.15" = "sha256-g3UbVVQjbZ82Nunat5a9RKwd73Y/mMtiCfAifr6k00U=";
-    };
-  };
+  buildInputs = [ systemd dbus openssl libssh2 libgit2 xz zlib ];
 
   postInstall = ''
     mv -v "$out/bin/ciel-rs" "$out/bin/ciel"
   '';
 
   meta = with lib; {
-    description = "A tool for controlling multi-layer file systems and containers.";
-    homepage = "https://www.rustup.rs/";
+    description = "A tool for controlling AOSC OS packaging environments using multi-layer filesystems and containers.";
+    homepage = "https://github.com/AOSC-Dev/ciel-rs";
     license = licenses.mit;
     platforms = platforms.unix;
     maintainers = with maintainers; [ yisuidenghua ];


### PR DESCRIPTION
###### Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

As suggested by NickCao:
- Removed anything related to `cargo.lock`. Although I'm not sure, I think it's fine before https://github.com/NixOS/nixpkgs/pull/217084 merged.
- Moved zlib to buildInputs.
- Fixed description, homepage and platforms metadata.
- Use "refs/tags/v${version}" for git rev.

Other changes:
- Find real path by convert symlink of libexec into absolute link https://github.com/AOSC-Dev/ciel-rs/pull/16.
- Use upstream-provided script to install plugin and completion files.
- Fix fish completion path https://github.com/AOSC-Dev/ciel-rs/pull/15.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- [ ] For non-Linux: Is `sandbox = true` set in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://nixos.org/manual/nixpkgs/unstable/#sec-package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [ ] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [23.05 Release Notes (or backporting 22.11 Release notes)](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#generating-2305-release-notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://nixos.org/manual/nixpkgs/unstable/#chap-reviewing-contributions
-->
