### PR TITLE
ciel: narrow platforms to linux

### DIFF
--- a/pkgs/tools/package-management/ciel/default.nix
+++ b/pkgs/tools/package-management/ciel/default.nix
@@ -52,7 +52,7 @@ rustPlatform.buildRustPackage rec {
     description = "A tool for controlling AOSC OS packaging environments using multi-layer filesystems and containers.";
     homepage = "https://github.com/AOSC-Dev/ciel-rs";
     license = licenses.mit;
-    platforms = platforms.unix;
+    platforms = platforms.linux;
     maintainers = with maintainers; [ yisuidenghua ];
   };
 }


### PR DESCRIPTION
###### Description of changes

platforms.linux actually as systemd is not available on other platforms.
Ref: https://github.com/NixOS/nixpkgs/pull/220006#discussion_r1132261588

###### Things done

N/A